### PR TITLE
Handle duplicate cookies.

### DIFF
--- a/src/pytest_vts/logic/machine.py
+++ b/src/pytest_vts/logic/machine.py
@@ -92,7 +92,7 @@ def _make_urllib3(http_prep_req):
             bodys = json.dumps(body)
         except ValueError:
             body = bodys = resp.data.decode("utf-8")
-        return resp.status, dict(resp.headers.items()), bodys
+        return resp.status, dict(resp.headers.itermerged()), bodys
 
 
 class Recorder(object):


### PR DESCRIPTION
Use HttpHeaderDict.itermerged() rather than .items() to preserve all cookie
values (as a single comma-separated value) where multiple cookies are received
with the same key.

https://github.com/urllib3/urllib3/blob/7d813bce9b1e39e45678209ccca771e825bc9472/src/urllib3/_collections.py#L294